### PR TITLE
First bash at integrating with ckanapi.datapackage

### DIFF
--- a/ckanext/downloadall/tasks.py
+++ b/ckanext/downloadall/tasks.py
@@ -3,9 +3,11 @@ import zipfile
 import os
 import urlparse
 import hashlib
+import io
 
 import requests
 from ckanapi import LocalCKAN
+import ckanapi.datapackage
 
 from ckan import model
 from ckan.plugins.toolkit import get_action
@@ -48,20 +50,6 @@ def update_zip(package_id):
             registry.action.resource_patch(
                 id=existing_zip_resource['id'],
                 **resource)
-        # package_zip = PackageZip.get_for_package(package_id)
-        # if not package_zip:
-        #     PackageZip.create(package_id, filepath, filesize,
-        #                       has_data=any_have_data)
-        #     log.info('Package zip created: %s', filepath)
-        # else:
-        #     package_zip.filepath = filepath
-        #     package_zip.updated = datetime.datetime.now()
-        #     package_zip.size = filesize
-        #     package_zip.has_data = any_have_data
-        #     log.info('Package zip updated: %s', filepath)
-
-        #     model.Session.add(package_zip)
-        #     model.Session.commit()
 
 
 def write_zip(fp, package_id):
@@ -76,67 +64,34 @@ def write_zip(fp, package_id):
         dataset = get_action('package_show')(
             context, {'id': package_id})
 
-        # download all the data and write it to the zip
+        # Ignore a pre-existing zip resource
         existing_zip_resource = None
-        for i, res in enumerate(dataset['resources']):
+        for res in dataset['resources'][:]:
             if res.get('downloadall_metadata_modified'):
-                # this is an existing zip of all the other resources
-                log.debug('Resource resource {}/{} skipped - is the zip itself'
-                          .format(i + 1, len(dataset['resources'])))
+                if existing_zip_resource:
+                    log.error(
+                        'Multiple "Download all zip" resources in dataset!')
                 existing_zip_resource = res
-                continue
+                dataset['resources'].remove(res)
 
-            # TODO deal with a resource of resource_type=file.upload
+        # download all the data and write it to the zip
+        # (requires https://github.com/ckan/ckanapi/commit/7ed29c0 )
+        ckanapi.datapackage.populate_datastore_fields(
+            ckan=LocalCKAN(), dataset=dataset)
+        with io.StringIO() as error_file:
+            datapackage_dir, datapackage, json_path = \
+                ckanapi.datapackage.create_datapackage(
+                    record=dataset, base_path='/tmp', stderr=error_file)
+            errors = error_file.getvalue()
+        if errors:
+            log.error('Error in create_datapackage(): {}'.format(errors))
+            raise Exception('Error in create_datapackage(): {}'.format(errors))
 
-            log.debug('Downloading resource {}/{}: {}'
-                      .format(i + 1, len(dataset['resources']), res['url']))
-            r = requests.get(res['url'], stream=True)
-            filename = os.path.basename(urlparse.urlparse(res['url']).path)
-            # TODO deal with duplicate filenames in the zip
-            hash_object = hashlib.md5()
-            try:
-                # python3 syntax - stream straight into the zip
-                with zipf.open(filename, 'wb') as zf:
-                    for chunk in r.iter_content(chunk_size=128):
-                        zf.write(chunk)
-                        hash_object.update(chunk)
-            except RuntimeError:
-                # python2 syntax - need to save to disk first
-                with tempfile.NamedTemporaryFile() as datafile:
-                    for chunk in r.iter_content(chunk_size=128):
-                        datafile.write(chunk)
-                        hash_object.update(chunk)
-                    datafile.flush()
-                    # .write() streams the file into the zip
-                    zipf.write(datafile.name, arcname=filename)
-            file_hash = hash_object.hexdigest()
-            # TODO optimize using the file_hash
-            file_hash
-        # TODO deal with a dataset with no resources
-
-        # TODO add the datapackage.json
-
-        # write HTML index
-        # env = jinja2.Environment(loader=jinja2.PackageLoader(
-        #     'ckanext.downloadll', 'templates'))
-        # env.filters['datetimeformat'] = datetimeformat
-        # template = env.get_template('index.html')
-        # zipf.writestr('index.html',
-        #     template.render(datapackage=datapackage,
-        #                     date=datetime.datetime.now()).encode('utf8'))
-
-        # Strip out unnecessary data from datapackage
-        # for res in datapackage['resources']:
-        #     del res['has_data']
-        #     if 'cache_filepath' in res:
-        #         del res['cache_filepath']
-        #     if 'reason' in res:
-        #         del res['reason']
-        #     if 'detected_format' in res:
-        #         del res['detected_format']
-
-        # zipf.writestr('datapackage.json',
-        #               json.dumps(datapackage, indent=4))
+        # copy the files into the zip
+        for i, res in enumerate(datapackage['resources']):
+            log.debug('Copying into zip resource {}/{}: {}'.format(
+                i + 1, len(datapackage['resources']), res['path']))
+            zipf.write(os.path.join(datapackage_dir, res['path']))
 
     statinfo = os.stat(fp.name)
     filesize = statinfo.st_size


### PR DESCRIPTION
@wardi This is an attempt to integrate the ckanapi.datapackage stuff, that downloads the files with unique filenames and writes the datapackage.json.

Requires a change to ckanapi, to return stuff:
```
diff --git a/ckanapi/datapackage.py b/ckanapi/datapackage.py
index 7895881..a739dd7 100644
--- a/ckanapi/datapackage.py
+++ b/ckanapi/datapackage.py
@@ -99,6 +99,8 @@ def create_datapackage(record, base_path, stderr):
     with open(json_path, 'wb') as out:
         out.write(pretty_json(datapackage))

+    return datapackage_dir, datapackage, json_path
+

 def populate_datastore_fields(ckan, dataset):
     """
```

TBH I prefer downloading the files and streaming them straight into the zip, rather than using ckanapi to save them to disk then adding them in. One less step. And I can do a log for each file. And I can calculate a hash of the file as it goes.

However I'm very keen to have use the resource_formats_to_ignore list, dataset_to_datapackage() and the code within the `for cres, dres in zip(ckan_resources, datapackage.get('resources', [])):`. I'm just keen to have the `for` loop in ckanext-downloadall code. I want to try factoring out the content of the loop so I can call it from ckanext-downloadall. Let me know what you think.