### PR TITLE
Fix the schema in the datapackage.json

### DIFF
--- a/ckanext/downloadall/tasks.py
+++ b/ckanext/downloadall/tasks.py
@@ -85,6 +85,8 @@ def write_zip(fp, package_id):
 
             ckanapi.datapackage.populate_datastore_res_fields(
                 ckan=ckan, res=res)
+            ckanapi.datapackage.populate_schema_from_datastore(
+                cres=res, dres=dres)
 
             log.debug('Downloading resource {}/{}: {}'
                       .format(i, len(dataset['resources']), res['url']))


### PR DESCRIPTION
Now datapackage.json contains the schema info, extracted from the Data Dictionary (assumes it was xloaded into DataStore or similar):
```
{
  "license": {
    "title": "Creative Commons Attribution",
    "type": "cc-by",
    "url": "http://www.opendefinition.org/licenses/cc-by"
  },
  "name": "test",
  "resources": [
    {
      "format": "CSV",
      "name": "annual-csv",
      "path": "annual-.csv",
      "schema": {
        "fields": [
          {
            "description": "Some description here!",
            "name": "Date",
            "title": "The Date",
            "type": "datetime"
          },
          {
            "name": "Price",
            "type": "number"
          }
        ]
      },
...
```