### PR TITLE
Fix travis postgres 10.1 error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ group: deprecated-2017Q4
 python:
   - 2.7
 env:
-  - CKANVERSION=master
+  # - CKANVERSION=master
   - CKANVERSION=2.7
   - CKANVERSION=2.8
 

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,15 @@ on ckanext-archiver and IPipe.)
 Requirements
 ------------
 
+=============== =============
+CKAN version    Compatibility
+=============== =============
+2.6 and earlier don't know
+2.7             yes
+2.8             yes
+2.9             no - needs updating
+=============== =============
+
 Designed to work with CKAN 2.7+
 
 Ideally it is used in conjunction with DataStore and

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -43,6 +43,7 @@ else
     # we need newer psycopg2 and corresponding exc name change
     sed -i -e 's/psycopg2==2.4.5/psycopg2==2.8.2/' requirements.txt
     sed -i -e 's/except sqlalchemy.exc.InternalError:/except (sqlalchemy.exc.InternalError, sqlalchemy.exc.DBAPIError):/' ckan/config/environment.py
+    sed -i -e 's/ connection.connection,/ connection.connection.connection,/' ckanext/datastore/backend/postgres.py
     pip install -r requirements.txt
 fi
 pip install -r dev-requirements.txt

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -38,6 +38,11 @@ if [ -f requirements-py2.txt ]
 then
     pip install -r requirements-py2.txt
 else
+    # To avoid error:
+    # Error: could not determine PostgreSQL version from '10.1'
+    # we need newer psycopg2 and corresponding exc name change
+    sed -i -e 's/psycopg2==2.4.5/psycopg2==2.8.2/' requirements.txt
+    sed -i -e 's/except sqlalchemy.exc.InternalError:/except (sqlalchemy.exc.InternalError, sqlalchemy.exc.DBAPIError):/' ckan/config/environment.py
     pip install -r requirements.txt
 fi
 pip install -r dev-requirements.txt


### PR DESCRIPTION
Seen in travis for tests against ckan 2.7 only, installing `psycopg2==2.4.5`:
```
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    Error: could not determine PostgreSQL version from '10.1'
```
Copied fix from https://github.com/davidread/ckanext-subscribe/blob/master/bin/travis-build.bash